### PR TITLE
small fix of  NullReferenceException in CredentiaManager.GetSharePointOnlineCredential 

### DIFF
--- a/Core/OfficeDevPnP.Core/Utilities/CredentialManager.cs
+++ b/Core/OfficeDevPnP.Core/Utilities/CredentialManager.cs
@@ -18,11 +18,12 @@ namespace OfficeDevPnP.Core.Utilities
         /// <returns>Microsoft.SharePoint.Client.SharePointOnlineCredentials</returns>
         public static SharePointOnlineCredentials GetSharePointOnlineCredential(string name)
         {
-            var networkCredential = GetCredential(name);
-
-            var credential = new SharePointOnlineCredentials(networkCredential.UserName,networkCredential.SecurePassword);
-
-            return credential;
+            var networkCredential = CredentialManager.GetCredential(name);
+            if (networkCredential == null)
+            {
+                return null;
+            }
+            return new SharePointOnlineCredentials(networkCredential.UserName, networkCredential.SecurePassword);
         }
 
         /// <summary>


### PR DESCRIPTION
There is public static method GetSharePointOnlineCredential  in the CredentiaManager (the first method from the top of the class ). It seems to be  not used inside of Library, but I allowed it to use. In case there is problem with credentials it crashes with NullReferenceException) 
Seeing   GetSharePointOnlineCredential  using  GetCredential method, which returns null  in case of no success, I allowed to ask for this simple pull request , where the GetSharePointOnlineCredential  similarly returns null in case of no success.